### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      all-pip:
+        patterns:
+          - "*"
+      all-pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- group all pip version updates into a single Dependabot PR
- group pip security updates separately so security fixes still aggregate cleanly
- keep the existing daily Dependabot schedule unchanged

## Verification

- validate .github/dependabot.yml parses as YAML